### PR TITLE
chore: loosen pydantic version constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "pydantic~=2.5.3",
+    "pydantic>=2.5.3,<3",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Right now, pydantic is set to `pydantic~=2.5.3` which means `2.6` range are deemed in-compatible.
This PR adjusts the contract to `>=2.5.3,<3` which allows Pydantic 2.6 range to work, which is needed for Ape to be able to use newer Pydantic versions, else it is stuck in 2.5 range.